### PR TITLE
:sparkles: serve hourly goerli data

### DIFF
--- a/pkg/core/config.go
+++ b/pkg/core/config.go
@@ -13,19 +13,13 @@ type Config struct {
 }
 
 func (c *Config) SleepDuration() time.Duration {
-	// Prater granularity defaults to 1 day
-	if c.Network == "mainnet" && c.Granularity == "hour" {
+	if c.Granularity == "hour" {
 		return time.Hour
 	} else {
 		return 24 * time.Hour
 	}
 }
 
-func (c* Config) Window() string {
-	// Prater granularity defaults to 1 day
-	if c.Network == "mainnet" {
-		return c.Granularity
-	} else {
-		return "day"
-	}
+func (c *Config) Window() string {
+	return c.Granularity
 }


### PR DESCRIPTION
```
INFO[0002] fetched statistics about key from rated network  attester-effectiveness=75.7201646090535 avg-correctness=0.9583333333333334 inclusion-delay=1.125 proposer-effectiveness=0 rewards=70646 uptime=0.8888888888888888 validation-key=XXX validator-effectiveness=75.7201646090535
INFO[0002] sleeping until next iteration                 sleep-for=59m57.132557125s
```